### PR TITLE
Add national id entity type

### DIFF
--- a/src/common.proto
+++ b/src/common.proto
@@ -28,6 +28,7 @@ enum FieldTypesEnum{
     US_PASSPORT = 14;
     US_SSN = 15;
     UK_NHS = 16;
+    NATIONAL_ID = 17;
 }
 
 // AnalyzeResult represents the Analyze service findings


### PR DESCRIPTION
Most countries will have a social security number or national identifier. Currently there is US_SSN and UK_NHS that covers USA and UK. To support other countries a more generic 'NATIONAL_ID'  entity type is added.